### PR TITLE
Add sensible SQLite default Pragmas (with ability to override)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,13 @@ and this project adheres to [Break Versioning](https://www.taoensso.com/break-ve
 
 ### Added
 
+- `Hanami::DB::SQLite::Pragmas` — a value class holding a set of SQLite
+  pragmas with sensible defaults, user overrides, and validation against
+  `PRAGMA pragma_list`. Exposes `#connect_sqls`, an array of `PRAGMA`
+  statements suitable for Sequel's per-connection `connect_sqls` option.
+  `UnknownPragmaError` is raised when an override names a pragma the
+  linked SQLite doesn't recognise.
+
 ### Changed
 
 ### Deprecated

--- a/lib/hanami/db/gem_inflector.rb
+++ b/lib/hanami/db/gem_inflector.rb
@@ -6,6 +6,7 @@ module Hanami
     class GemInflector < Zeitwerk::GemInflector
       def camelize(basename, _abspath)
         return "DB" if basename == "db"
+        return "SQLite" if basename == "sqlite"
 
         super
       end

--- a/lib/hanami/db/sqlite.rb
+++ b/lib/hanami/db/sqlite.rb
@@ -3,6 +3,7 @@
 module Hanami
   module DB
     module SQLite
+      MEMORY_URL = RUBY_ENGINE == "jruby" ? "jdbc:sqlite::memory:" : "sqlite::memory:"
     end
   end
 end

--- a/lib/hanami/db/sqlite.rb
+++ b/lib/hanami/db/sqlite.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+module Hanami
+  module DB
+    module SQLite
+    end
+  end
+end

--- a/lib/hanami/db/sqlite/pragmas.rb
+++ b/lib/hanami/db/sqlite/pragmas.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require "sqlite3"
-
 module Hanami
   module DB
     module SQLite
@@ -18,6 +16,9 @@ module Hanami
         NAMES_MUTEX = Mutex.new
         private_constant :NAMES_MUTEX
 
+        MEMORY_URL = RUBY_PLATFORM == "java" ? "jdbc:sqlite::memory:" : "sqlite::memory:"
+        private_constant :MEMORY_URL
+
         # The authoritative set of pragma names SQLite recognises, queried
         # via `PRAGMA pragma_list` (here through its table-valued form,
         # `pragma_pragma_list`) against a transient in-memory connection
@@ -29,10 +30,10 @@ module Hanami
         def self.names
           @names || NAMES_MUTEX.synchronize do
             @names ||= begin
-              db = ::SQLite3::Database.new(":memory:")
-              db.execute("SELECT name FROM pragma_pragma_list").flatten.map(&:to_sym).to_set.freeze
+              db = Sequel.connect(MEMORY_URL)
+              db.fetch("SELECT name FROM pragma_pragma_list").map { |row| row[:name].to_sym }.to_set.freeze
             ensure
-              db&.close
+              db&.disconnect
             end
           end
         end

--- a/lib/hanami/db/sqlite/pragmas.rb
+++ b/lib/hanami/db/sqlite/pragmas.rb
@@ -24,9 +24,8 @@ module Hanami
         # on first access. Reflects whatever SQLite the runtime has linked,
         # so newer pragmas appear automatically without a gem upgrade.
         # Memoized at the class level; the in-memory handle is opened at
-        # most once per class load, and not at all if `self.names` is
-        # never called. The mutex guards concurrent first access (e.g.
-        # parallel connection warmup at boot).
+        # most once per class load. The mutex guards concurrent first
+        # access (e.g. parallel connection warmup at boot).
         def self.names
           @names || NAMES_MUTEX.synchronize do
             @names ||= begin
@@ -38,10 +37,10 @@ module Hanami
           end
         end
 
-        def initialize(overrides: {}, clear_defaults: false, validate: true)
+        def initialize(overrides: {}, clear_defaults: false)
           base = clear_defaults ? {} : DEFAULTS
           @resolved = base.merge(overrides.transform_keys(&:to_sym)).freeze
-          validate_names! if validate
+          validate_names!
         end
 
         def to_h

--- a/lib/hanami/db/sqlite/pragmas.rb
+++ b/lib/hanami/db/sqlite/pragmas.rb
@@ -12,7 +12,7 @@ module Hanami
           synchronous: :normal,
           mmap_size: 128 * 1024 * 1024,
           journal_size_limit: 64 * 1024 * 1024,
-          cache_size: 2_000,
+          cache_size: 2_000
         }.freeze
 
         NAMES_MUTEX = Mutex.new

--- a/lib/hanami/db/sqlite/pragmas.rb
+++ b/lib/hanami/db/sqlite/pragmas.rb
@@ -16,9 +16,6 @@ module Hanami
         NAMES_MUTEX = Mutex.new
         private_constant :NAMES_MUTEX
 
-        MEMORY_URL = RUBY_ENGINE == "jruby" ? "jdbc:sqlite::memory:" : "sqlite::memory:"
-        private_constant :MEMORY_URL
-
         # The authoritative set of pragma names SQLite recognises, queried
         # via `PRAGMA pragma_list` (here through its table-valued form,
         # `pragma_pragma_list`) against a transient in-memory connection

--- a/lib/hanami/db/sqlite/pragmas.rb
+++ b/lib/hanami/db/sqlite/pragmas.rb
@@ -1,0 +1,64 @@
+# frozen_string_literal: true
+
+require "sqlite3"
+
+module Hanami
+  module DB
+    module SQLite
+      class Pragmas
+        DEFAULTS = {
+          foreign_keys: true,
+          journal_mode: :wal,
+          synchronous: :normal,
+          mmap_size: 128 * 1024 * 1024,
+          journal_size_limit: 64 * 1024 * 1024,
+          cache_size: 2_000,
+        }.freeze
+
+        NAMES_MUTEX = Mutex.new
+        private_constant :NAMES_MUTEX
+
+        # The authoritative set of pragma names SQLite recognises, queried
+        # via `PRAGMA pragma_list` (here through its table-valued form,
+        # `pragma_pragma_list`) against a transient in-memory connection
+        # on first access. Reflects whatever SQLite the runtime has linked,
+        # so newer pragmas appear automatically without a gem upgrade.
+        # Memoized at the class level; the in-memory handle is opened at
+        # most once per class load, and not at all if `self.names` is
+        # never called. The mutex guards concurrent first access (e.g.
+        # parallel connection warmup at boot).
+        def self.names
+          @names || NAMES_MUTEX.synchronize do
+            @names ||= begin
+              db = ::SQLite3::Database.new(":memory:")
+              db.execute("SELECT name FROM pragma_pragma_list").flatten.map(&:to_sym).to_set.freeze
+            ensure
+              db&.close
+            end
+          end
+        end
+
+        def initialize(overrides: {}, clear_defaults: false, validate: true)
+          base = clear_defaults ? {} : DEFAULTS
+          @resolved = base.merge(overrides.transform_keys(&:to_sym)).freeze
+          validate_names! if validate
+        end
+
+        def to_h
+          @resolved
+        end
+
+        def connect_sqls
+          @resolved.map { |name, value| "PRAGMA #{name} = #{value}" }
+        end
+
+        private
+
+        def validate_names!
+          unknown = @resolved.keys.reject { self.class.names.include?(_1) }
+          raise UnknownPragmaError.new(unknown) unless unknown.empty?
+        end
+      end
+    end
+  end
+end

--- a/lib/hanami/db/sqlite/pragmas.rb
+++ b/lib/hanami/db/sqlite/pragmas.rb
@@ -16,7 +16,7 @@ module Hanami
         NAMES_MUTEX = Mutex.new
         private_constant :NAMES_MUTEX
 
-        MEMORY_URL = RUBY_PLATFORM == "java" ? "jdbc:sqlite::memory:" : "sqlite::memory:"
+        MEMORY_URL = RUBY_ENGINE == "jruby" ? "jdbc:sqlite::memory:" : "sqlite::memory:"
         private_constant :MEMORY_URL
 
         # The authoritative set of pragma names SQLite recognises, queried

--- a/lib/hanami/db/sqlite/unknown_pragma_error.rb
+++ b/lib/hanami/db/sqlite/unknown_pragma_error.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+module Hanami
+  module DB
+    module SQLite
+      class UnknownPragmaError < StandardError
+        attr_reader :unknown
+
+        def initialize(unknown)
+          @unknown = unknown.dup.freeze
+          super(build_message(@unknown))
+        end
+
+        private
+
+        def build_message(unknown)
+          "Unknown SQLite pragma(s): #{unknown.join(", ")}. " \
+            "If you have confirmed this pragma is supported by your SQLite build, " \
+            "construct Hanami::DB::SQLite::Pragmas with `validate: false` to bypass " \
+            "name validation."
+        end
+      end
+    end
+  end
+end

--- a/lib/hanami/db/sqlite/unknown_pragma_error.rb
+++ b/lib/hanami/db/sqlite/unknown_pragma_error.rb
@@ -14,10 +14,7 @@ module Hanami
         private
 
         def build_message(unknown)
-          "Unknown SQLite pragma(s): #{unknown.join(", ")}. " \
-            "If you have confirmed this pragma is supported by your SQLite build, " \
-            "construct Hanami::DB::SQLite::Pragmas with `validate: false` to bypass " \
-            "name validation."
+          "Unknown SQLite pragma(s): #{unknown.join(", ")}."
         end
       end
     end

--- a/spec/integration/sqlite/pragmas_spec.rb
+++ b/spec/integration/sqlite/pragmas_spec.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+require "sequel"
+require "tempfile"
+
+RSpec.describe "SQLite Pragmas integration" do
+  subject(:pragmas) { Hanami::DB::SQLite::Pragmas.new(overrides: overrides) }
+
+  let(:overrides) { {synchronous: :full} }
+  let(:tempfile) { Tempfile.new(["hanami-db-pragmas", ".sqlite"]) }
+  let(:db) do
+    Sequel.connect(sqlite_file_database_url(tempfile.path), connect_sqls: pragmas.connect_sqls)
+  end
+
+  after do
+    db.disconnect
+    tempfile.close
+    tempfile.unlink
+  end
+
+  def pragma(name)
+    db.fetch("PRAGMA #{name}").first&.fetch(name)
+  end
+
+  it "sets foreign_keys" do
+    expect(pragma(:foreign_keys).to_i).to eq(1)
+  end
+
+  it "sets journal_mode to wal" do
+    expect(pragma(:journal_mode)).to eq("wal")
+  end
+
+  it "applies user overrides over defaults" do
+    expect(pragma(:synchronous).to_i).to eq(2) # full = 2
+  end
+
+  it "leaves unrelated defaults applied" do
+    expect(pragma(:cache_size).to_i).to eq(2_000)
+  end
+
+  it "applies the pragmas to every new pool connection, not just the first" do
+    # Force a second physical connection to be opened from the pool.
+    db.pool.hold { |_conn| }
+    db.pool.hold { |_conn| }
+
+    expect(pragma(:journal_mode)).to eq("wal")
+  end
+end

--- a/spec/support/helpers.rb
+++ b/spec/support/helpers.rb
@@ -9,6 +9,14 @@ module Test
         "sqlite:file::memory:?cache=private"
       end
     end
+
+    def sqlite_file_database_url(path)
+      if RUBY_PLATFORM == "java"
+        "jdbc:sqlite:#{path}"
+      else
+        "sqlite://#{path}"
+      end
+    end
   end
 end
 

--- a/spec/support/helpers.rb
+++ b/spec/support/helpers.rb
@@ -3,7 +3,7 @@
 module Test
   module Helpers
     def sqlite_memory_database_url
-      if RUBY_PLATFORM == "java"
+      if RUBY_ENGINE == "jruby"
         "jdbc:sqlite:file::memory:?cache=private"
       else
         "sqlite:file::memory:?cache=private"
@@ -11,7 +11,7 @@ module Test
     end
 
     def sqlite_file_database_url(path)
-      if RUBY_PLATFORM == "java"
+      if RUBY_ENGINE == "jruby"
         "jdbc:sqlite:#{path}"
       else
         "sqlite://#{path}"

--- a/spec/unit/sqlite/pragmas_spec.rb
+++ b/spec/unit/sqlite/pragmas_spec.rb
@@ -112,17 +112,6 @@ RSpec.describe Hanami::DB::SQLite::Pragmas do
       end
     end
 
-    context "with validate: false and an unknown override" do
-      let(:args) { {overrides: {frobnicate: 1}, validate: false} }
-
-      it "does not raise" do
-        expect { subject }.not_to raise_error
-      end
-
-      it "still includes the unknown pragma in the resolved set" do
-        expect(subject.to_h.fetch(:frobnicate)).to eq(1)
-      end
-    end
   end
 
   describe ".names" do
@@ -137,14 +126,6 @@ RSpec.describe Hanami::DB::SQLite::Pragmas do
       3.times { described_class.new(clear_defaults: true, overrides: {foreign_keys: 1}) }
 
       expect(SQLite3::Database).to have_received(:new).once
-    end
-
-    it "does not open a connection when no instance ever validates" do
-      allow(SQLite3::Database).to receive(:new)
-
-      described_class.new(overrides: {frobnicate: 1}, validate: false)
-
-      expect(SQLite3::Database).not_to have_received(:new)
     end
   end
 

--- a/spec/unit/sqlite/pragmas_spec.rb
+++ b/spec/unit/sqlite/pragmas_spec.rb
@@ -114,17 +114,17 @@ RSpec.describe Hanami::DB::SQLite::Pragmas do
   end
 
   describe ".names" do
-    let(:fake_db) { instance_double(SQLite3::Database, execute: [["foreign_keys"]], close: nil) }
+    let(:fake_db) { instance_double(Sequel::Database, fetch: [{name: "foreign_keys"}], disconnect: nil) }
 
     before { described_class.instance_variable_set(:@names, nil) }
     after { described_class.instance_variable_set(:@names, nil) }
 
     it "opens the :memory: connection only once across many validations" do
-      allow(SQLite3::Database).to receive(:new).and_return(fake_db)
+      allow(Sequel).to receive(:connect).and_return(fake_db)
 
       3.times { described_class.new(clear_defaults: true, overrides: {foreign_keys: 1}) }
 
-      expect(SQLite3::Database).to have_received(:new).once
+      expect(Sequel).to have_received(:connect).once
     end
   end
 

--- a/spec/unit/sqlite/pragmas_spec.rb
+++ b/spec/unit/sqlite/pragmas_spec.rb
@@ -1,0 +1,168 @@
+# frozen_string_literal: true
+
+RSpec.describe Hanami::DB::SQLite::Pragmas do
+  subject { described_class.new(**args) }
+
+  let(:args) { {} }
+
+  describe "DEFAULTS" do
+    it "is frozen" do
+      expect(described_class::DEFAULTS).to be_frozen
+    end
+
+    it "is the chosen set of pragmas" do
+      expect(described_class::DEFAULTS).to eq(
+        foreign_keys: true,
+        journal_mode: :wal,
+        synchronous: :normal,
+        mmap_size: 128 * 1024 * 1024,
+        journal_size_limit: 64 * 1024 * 1024,
+        cache_size: 2_000,
+      )
+    end
+  end
+
+  describe "#to_h" do
+    context "with no arguments" do
+      it "returns the default set" do
+        expect(subject.to_h).to eq(described_class::DEFAULTS)
+      end
+    end
+
+    context "with overrides" do
+      let(:args) { {overrides: {synchronous: "full", cache_size: 4_000}} }
+
+      it "overrides matching defaults" do
+        expect(subject.to_h.fetch(:synchronous)).to eq("full")
+      end
+
+      it "replaces overridden default values" do
+        expect(subject.to_h.fetch(:cache_size)).to eq(4_000)
+      end
+
+      it "keeps unaffected defaults" do
+        expect(subject.to_h.fetch(:journal_mode)).to eq(:wal)
+      end
+    end
+
+    context "with clear_defaults: true" do
+      let(:args) { {clear_defaults: true, overrides: {foreign_keys: 1}} }
+
+      it "drops the entire default set" do
+        expect(subject.to_h.keys).to eq([:foreign_keys])
+      end
+    end
+
+    context "with clear_defaults: true and no overrides" do
+      let(:args) { {clear_defaults: true} }
+
+      it "produces an empty resolved set" do
+        expect(subject.to_h).to be_empty
+      end
+    end
+
+    context "with string-keyed overrides" do
+      let(:args) { {overrides: {"synchronous" => "full"}} }
+
+      it "normalizes the key to a symbol" do
+        expect(subject.to_h.fetch(:synchronous)).to eq("full")
+      end
+
+      it "does not leak the string key into the resolved set" do
+        expect(subject.to_h.keys).to all(be_a(Symbol))
+      end
+    end
+  end
+
+  describe "validation" do
+    context "with an unknown override pragma name" do
+      let(:args) { {overrides: {frobnicate: 1}} }
+
+      it "raises UnknownPragmaError" do
+        expect { subject }.to raise_error(
+          Hanami::DB::SQLite::UnknownPragmaError,
+          /frobnicate/,
+        )
+      end
+
+      it "lists every unknown name when multiple are given" do
+        multi_args = {overrides: {frobnicate: 1, wibble: 2}}
+        expect { described_class.new(**multi_args) }.to raise_error(
+          Hanami::DB::SQLite::UnknownPragmaError,
+        ) { |e| expect(e.unknown).to contain_exactly(:frobnicate, :wibble) }
+      end
+    end
+
+    context "with a known override pragma name" do
+      let(:args) { {overrides: {temp_store: "memory"}} }
+
+      it "does not raise" do
+        expect { subject }.not_to raise_error
+      end
+    end
+
+    context "with clear_defaults: true and an unknown override" do
+      let(:args) { {clear_defaults: true, overrides: {frobnicate: 1}} }
+
+      it "still raises UnknownPragmaError" do
+        expect { subject }.to raise_error(
+          Hanami::DB::SQLite::UnknownPragmaError,
+          /frobnicate/,
+        )
+      end
+    end
+
+    context "with validate: false and an unknown override" do
+      let(:args) { {overrides: {frobnicate: 1}, validate: false} }
+
+      it "does not raise" do
+        expect { subject }.not_to raise_error
+      end
+
+      it "still includes the unknown pragma in the resolved set" do
+        expect(subject.to_h.fetch(:frobnicate)).to eq(1)
+      end
+    end
+  end
+
+  describe ".names" do
+    let(:fake_db) { instance_double(SQLite3::Database, execute: [["foreign_keys"]], close: nil) }
+
+    before { described_class.instance_variable_set(:@names, nil) }
+    after { described_class.instance_variable_set(:@names, nil) }
+
+    it "opens the :memory: connection only once across many validations" do
+      allow(SQLite3::Database).to receive(:new).and_return(fake_db)
+
+      3.times { described_class.new(clear_defaults: true, overrides: {foreign_keys: 1}) }
+
+      expect(SQLite3::Database).to have_received(:new).once
+    end
+
+    it "does not open a connection when no instance ever validates" do
+      allow(SQLite3::Database).to receive(:new)
+
+      described_class.new(overrides: {frobnicate: 1}, validate: false)
+
+      expect(SQLite3::Database).not_to have_received(:new)
+    end
+  end
+
+  describe "#connect_sqls" do
+    let(:args) { {overrides: {synchronous: :full}} }
+
+    it "returns one `PRAGMA name = value` statement per resolved pragma" do
+      expect(subject.connect_sqls).to contain_exactly(
+        *subject.to_h.map { |name, value| "PRAGMA #{name} = #{value}" },
+      )
+    end
+
+    it "interpolates overridden values" do
+      expect(subject.connect_sqls).to include("PRAGMA synchronous = full")
+    end
+
+    it "preserves the resolved insertion order" do
+      expect(subject.connect_sqls.first).to eq("PRAGMA foreign_keys = true")
+    end
+  end
+end

--- a/spec/unit/sqlite/pragmas_spec.rb
+++ b/spec/unit/sqlite/pragmas_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe Hanami::DB::SQLite::Pragmas do
         synchronous: :normal,
         mmap_size: 128 * 1024 * 1024,
         journal_size_limit: 64 * 1024 * 1024,
-        cache_size: 2_000,
+        cache_size: 2_000
       )
     end
   end
@@ -81,14 +81,14 @@ RSpec.describe Hanami::DB::SQLite::Pragmas do
       it "raises UnknownPragmaError" do
         expect { subject }.to raise_error(
           Hanami::DB::SQLite::UnknownPragmaError,
-          /frobnicate/,
+          /frobnicate/
         )
       end
 
       it "lists every unknown name when multiple are given" do
         multi_args = {overrides: {frobnicate: 1, wibble: 2}}
         expect { described_class.new(**multi_args) }.to raise_error(
-          Hanami::DB::SQLite::UnknownPragmaError,
+          Hanami::DB::SQLite::UnknownPragmaError
         ) { |e| expect(e.unknown).to contain_exactly(:frobnicate, :wibble) }
       end
     end
@@ -107,11 +107,10 @@ RSpec.describe Hanami::DB::SQLite::Pragmas do
       it "still raises UnknownPragmaError" do
         expect { subject }.to raise_error(
           Hanami::DB::SQLite::UnknownPragmaError,
-          /frobnicate/,
+          /frobnicate/
         )
       end
     end
-
   end
 
   describe ".names" do
@@ -134,7 +133,7 @@ RSpec.describe Hanami::DB::SQLite::Pragmas do
 
     it "returns one `PRAGMA name = value` statement per resolved pragma" do
       expect(subject.connect_sqls).to contain_exactly(
-        *subject.to_h.map { |name, value| "PRAGMA #{name} = #{value}" },
+        *subject.to_h.map { |name, value| "PRAGMA #{name} = #{value}" }
       )
     end
 

--- a/spec/unit/sqlite/unknown_pragma_error_spec.rb
+++ b/spec/unit/sqlite/unknown_pragma_error_spec.rb
@@ -14,10 +14,6 @@ RSpec.describe Hanami::DB::SQLite::UnknownPragmaError do
     expect(subject.message).to include("wibble")
   end
 
-  it "mentions the validation opt-out" do
-    expect(subject.message).to include("validate: false")
-  end
-
   it "exposes the unknown pragma names" do
     expect(subject.unknown).to eq([:frobnicate, :wibble])
   end

--- a/spec/unit/sqlite/unknown_pragma_error_spec.rb
+++ b/spec/unit/sqlite/unknown_pragma_error_spec.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+RSpec.describe Hanami::DB::SQLite::UnknownPragmaError do
+  subject { described_class.new(unknown_pragmas) }
+
+  let(:unknown_pragmas) { [:frobnicate, :wibble] }
+
+  it "is a StandardError" do
+    expect(subject).to be_a(StandardError)
+  end
+
+  it "lists the unknown pragma names in the message" do
+    expect(subject.message).to include("frobnicate")
+    expect(subject.message).to include("wibble")
+  end
+
+  it "mentions the validation opt-out" do
+    expect(subject.message).to include("validate: false")
+  end
+
+  it "exposes the unknown pragma names" do
+    expect(subject.unknown).to eq([:frobnicate, :wibble])
+  end
+
+  it "exposes a frozen copy of the unknown pragma names" do
+    expect(subject.unknown).to be_frozen
+  end
+
+  context "with a single unknown pragma" do
+    subject { described_class.new([:frobnicate]) }
+
+    it "formats the name plainly in the message" do
+      expect(subject.message).to include("frobnicate")
+    end
+
+    it "does not render the names as an inspected array" do
+      expect(subject.message).not_to include("[:frobnicate]")
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Adds `Hanami::DB::SQLite::Pragmas`, a small value class that holds a set of SQLite pragmas with sensible defaults, accepts user overrides, validates pragma names against the linked SQLite, and exposes `#connect_sqls`, which is an array of `PRAGMA` statements suitable for Sequel's per-connection `:connect_sqls` hook.

This matches @fractaledmind's [recommendations,](https://fractaledmind.com/2023/09/21/enhancing-rails-sqlite-performance-metrics/) which [landed in Rails](https://github.com/rails/rails/pull/49349):

| pragma | value |
|---|---|
| `journal_mode` | `:wal` |
| `synchronous` | `:normal` |
| `mmap_size` | 128 MiB |
| `journal_size_limit` | 64 MiB |
| `cache_size` | 2000 pages |


## Usage

```ruby
# Just the defaults
pragmas = Hanami::DB::SQLite::Pragmas.new

# Override individual values; defaults still apply for the rest
pragmas = Hanami::DB::SQLite::Pragmas.new(overrides: {synchronous: :full})

# Drop the defaults entirely
pragmas = Hanami::DB::SQLite::Pragmas.new(clear_defaults: true, overrides: {…})

# Wire into Sequel
Sequel.connect(url, connect_sqls: pragmas.connect_sqls)
```

To try these out in a full-stack `hanami` app, use:

```ruby
config.gateway(:default) do |gateway|
  gateway.connection_options(connect_sqls: Hanami::DB::SQLite::Pragmas.new.connect_sqls)
end
```

And verify with `Hanami.app["db.gateway"].fetch("PRAGMA journal_mode").first`.

In my app, benchmarking the 23 endpoints I have with a 'realistic' read-heavy load (on a file-based SQLite db), reads improved ~10% on average, and 3-25% faster for p95 (mostly 10-15%). For writes, most writes were much faster (30-50%), while some degraded slightly (by a small amount).

Importantly, there were some really bad p95 values of 5s+ which are gone now, which matters even more than the modest/significant performance increase above.

I'll open a PR to make this the default experience in `hanami/hanami` once this lands, so all SQLite users will benefit from it.

## Design notes

- **Name validation** runs against the linked SQLite's own `pragma_list` (via the `pragma_pragma_list` table-valued function), so newer pragmas are recognised automatically without a gem upgrade.
-  **Per-connection by design.** PRAGMA state lives on the connection, not the database. `#connect_sqls` returns an array of SQL strings that Sequel applies via its `:connect_sqls` option to *every* new physical connection the pool opens. An `:after_connect` callback would have been the wrong abstraction: Sequel passes the raw adapter handle (`SQLite3::Database`), not a `Sequel::Database`, and a one-shot call against a single `Sequel::Database` would only configure whichever pool member happened to handle that call.
- **Always validates names.** [I originally had an option]([3b0b374](https://github.com/hanami/hanami-db/pull/21/commits/3b0b374508310c03c14b444fd5b29d2acdec1d29)) where users could pass in `validate: false`, based on when I was validating against the sqlite3 gem, but I switched the method to call a query, and I can't think of any reason why anyone would want to skip validation, except one: using a very old SQLite version. The PRAGMA LISt was added in SQLite 3.20.0 which was released August 2017. I highly doubt anyone will be connecting to a DB that old with Hanami, but I'm open to putting it back in as an escape valve. It does open a connection to `:memory:` on call but that's in every SQLite compilation and is extremely fast, plus it's only run once.


### Disclosure
I used AI to write this PR, validate its behavior. I've personally reviewed all of the code and tested it.