### PR TITLE
Transform jdbc: URLs in Hanami::DB::Testing.database_url

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,21 @@ and this project adheres to [Break Versioning](https://www.taoensso.com/break-ve
 
 ### Fixed
 
+- `Hanami::DB::Testing.database_url` now transforms `jdbc:` database URLs. Previously it returned them
+  unchanged, so with `HANAMI_ENV=test` the test database URL still pointed at the **development**
+  database, and running the test suite truncated or migrated development data. This affected JRuby
+  applications, which are the only ones that must use `jdbc:` URLs.
+
+  The `jdbc:postgresql:`, `jdbc:mysql:` and `jdbc:sqlite:` subprotocols are transformed, in both the
+  `jdbc:sqlite://db/app.db` and single-colon `jdbc:sqlite:db/app.db` forms, including SQLite's
+  Windows drive-letter (`jdbc:sqlite:C:/db/app.db`) and `file:` URI filename
+  (`jdbc:sqlite:file:db/app.db?mode=ro`) paths. Other subprotocols — `jdbc:sqlserver:`, `jdbc:h2:`,
+  `jdbc:derby:` and the rest — name their databases in ways this transformation does not understand,
+  and continue to be returned untouched. In-memory SQLite databases (`sqlite::memory:`,
+  `jdbc:sqlite:file::memory:?cache=private`, `jdbc:sqlite:file:app?mode=memory`) are also left alone.
+- `Hanami::DB::Testing.database_url` now transforms the single-colon `sqlite:db/development.sqlite3`
+  form on CRuby too, not only behind a `jdbc:` prefix. Previously it was returned unchanged.
+
 ### Security
 
 [Unreleased]: https://github.com/hanami/hanami-db/compare/v3.0.0...main

--- a/lib/hanami/db/testing.rb
+++ b/lib/hanami/db/testing.rb
@@ -28,8 +28,8 @@ module Hanami
       #
       # @api private
       # @since 3.0.1
-      JDBC_SUBPROTOCOLS = ["postgresql:", "mysql:", "sqlite:"].freeze
-      private_constant :JDBC_SUBPROTOCOLS
+      JDBC_SUPPORTED_SUBPROTOCOLS = ["postgresql:", "mysql:", "sqlite:"].freeze
+      private_constant :JDBC_SUPPORTED_SUBPROTOCOLS
 
       # Prefix of a SQLite URI filename, e.g. "file:db/app.sqlite3?mode=ro"
       #
@@ -51,14 +51,6 @@ module Hanami
       # @since 3.0.1
       SQLITE_MEMORY_QUERY = "mode=memory"
       private_constant :SQLITE_MEMORY_QUERY
-
-      # Matches a SQLite filename, optionally led by a Windows drive letter.
-      # Anchored, since a stray colon means an in-memory database.
-      #
-      # @api private
-      # @since 3.0.1
-      SQLITE_FILENAME_MATCHER = /\A([A-Za-z]:)?[^:]+\z/
-      private_constant :SQLITE_FILENAME_MATCHER
 
       class << self
         # @api private
@@ -90,7 +82,7 @@ module Hanami
         def jdbc_database_url(url)
           rest = url.delete_prefix(JDBC_PREFIX)
 
-          return url unless rest.start_with?(*JDBC_SUBPROTOCOLS)
+          return url unless rest.start_with?(*JDBC_SUPPORTED_SUBPROTOCOLS)
 
           JDBC_PREFIX + transform(URI(rest))
         rescue URI::Error
@@ -180,7 +172,6 @@ module Hanami
 
           return opaque if filename.match?(SQLITE_MEMORY_MATCHER)
           return opaque if query.include?(SQLITE_MEMORY_QUERY)
-          return opaque unless filename.match?(SQLITE_FILENAME_MATCHER)
 
           prefix + database_filename(filename) + separator + query
         end

--- a/lib/hanami/db/testing.rb
+++ b/lib/hanami/db/testing.rb
@@ -17,17 +17,102 @@ module Hanami
       DATABASE_NAME_MATCHER = /_dev(elopment)?$/
       private_constant :DATABASE_NAME_MATCHER
 
+      # Prefix of the JDBC URLs that JRuby applications must use
+      #
+      # @api private
+      # @since 3.0.1
+      JDBC_PREFIX = "jdbc:"
+      private_constant :JDBC_PREFIX
+
+      # JDBC subprotocols whose URLs this transformation understands
+      #
+      # @api private
+      # @since 3.0.1
+      JDBC_SUBPROTOCOLS = ["postgresql:", "mysql:", "sqlite:"].freeze
+      private_constant :JDBC_SUBPROTOCOLS
+
+      # Prefix of a SQLite URI filename, e.g. "file:db/app.sqlite3?mode=ro"
+      #
+      # @api private
+      # @since 3.0.1
+      SQLITE_FILE_PREFIX = "file:"
+      private_constant :SQLITE_FILE_PREFIX
+
+      # Matches a SQLite in-memory database, which names no file on disk
+      #
+      # @api private
+      # @since 3.0.1
+      SQLITE_MEMORY_MATCHER = /\A:memory:?\z/
+      private_constant :SQLITE_MEMORY_MATCHER
+
+      # Marks a SQLite URI filename as in-memory, e.g. "file:app?mode=memory"
+      #
+      # @api private
+      # @since 3.0.1
+      SQLITE_MEMORY_QUERY = "mode=memory"
+      private_constant :SQLITE_MEMORY_QUERY
+
+      # Matches a SQLite filename, optionally led by a Windows drive letter.
+      # Anchored, since a stray colon means an in-memory database.
+      #
+      # @api private
+      # @since 3.0.1
+      SQLITE_FILENAME_MATCHER = /\A([A-Za-z]:)?[^:]+\z/
+      private_constant :SQLITE_FILENAME_MATCHER
+
       class << self
         # @api private
         # @since 2.2.0
         def database_url(url)
+          url = url.to_s
+
+          return jdbc_database_url(url) if url.start_with?(JDBC_PREFIX)
+
           # URI#dup does not duplicate internal instance
           # variables, making mutation dangerous.
-          url = URI(url.to_s)
+          transform(URI(url))
+        end
 
+        private
+
+        # Transform a JDBC URL by stripping its prefix, transforming the
+        # remainder, then reattaching the prefix.
+        #
+        # Subprotocols we do not understand, and remainders URI cannot parse,
+        # are returned untouched: mangling such a URL is worse than no-opping.
+        #
+        # @param url [String] JDBC database URL
+        #
+        # @return [String]
+        #
+        # @api private
+        # @since 3.0.1
+        def jdbc_database_url(url)
+          rest = url.delete_prefix(JDBC_PREFIX)
+
+          return url unless rest.start_with?(*JDBC_SUBPROTOCOLS)
+
+          JDBC_PREFIX + transform(URI(rest))
+        rescue URI::Error
+          url
+        end
+
+        # Transform a parsed database URL into its test equivalent.
+        #
+        # @param url [URI] Database URL parsed as URI::Generic
+        #
+        # @return [String]
+        #
+        # @api private
+        # @since 3.0.1
+        def transform(url)
           case deconstruct_url(url)
           in {scheme: "sqlite", opaque: nil, path:} unless path.nil?
             url.path = database_filename(path)
+          in {scheme: "sqlite", opaque: String => opaque, path: nil}
+            url.opaque = sqlite_opaque(opaque)
+          in {scheme: "postgres" | "postgresql" | "mysql", opaque: String => opaque, path: nil}
+            url.opaque = database_opaque(opaque)
           in {path: String => path} if path =~ DATABASE_NAME_MATCHER
             url.path = path.sub(DATABASE_NAME_MATCHER, DATABASE_NAME_SUFFIX)
           in {path: String => path} unless path.end_with?(DATABASE_NAME_SUFFIX)
@@ -38,8 +123,6 @@ module Hanami
 
           url.to_s
         end
-
-        private
 
         # Deconstructs a URI::Generic for pattern-matching.
         #
@@ -53,6 +136,53 @@ module Hanami
           %i[opaque path scheme].each_with_object({}) do |part, hash|
             hash[part] = url.public_send(part)
           end
+        end
+
+        # Transform database name as with URI paths, for single-colon URLs such
+        # as "jdbc:postgresql:bookshelf_development", where URI parses the name
+        # into #opaque rather than #path, with any query string folded in.
+        #
+        # @param opaque [String] opaque component from URI
+        #
+        # @return [String]
+        #
+        # @api private
+        # @since 3.0.1
+        def database_opaque(opaque)
+          database, separator, query = opaque.partition("?")
+
+          if database =~ DATABASE_NAME_MATCHER
+            database = database.sub(DATABASE_NAME_MATCHER, DATABASE_NAME_SUFFIX)
+          elsif !database.end_with?(DATABASE_NAME_SUFFIX)
+            database += DATABASE_NAME_SUFFIX
+          end
+
+          database + separator + query
+        end
+
+        # Transform filename as with URI paths, for single-colon SQLite URLs
+        # such as "jdbc:sqlite:db/development.sqlite3".
+        #
+        # SQLite spells its in-memory databases in this same component
+        # (":memory:", "file::memory:?cache=private", "file:app?mode=memory").
+        # Those name no file on disk, so they are returned untouched.
+        #
+        # @param opaque [String] opaque component from URI
+        #
+        # @return [String]
+        #
+        # @api private
+        # @since 3.0.1
+        def sqlite_opaque(opaque)
+          location, separator, query = opaque.partition("?")
+          prefix = location.start_with?(SQLITE_FILE_PREFIX) ? SQLITE_FILE_PREFIX : ""
+          filename = location.delete_prefix(prefix)
+
+          return opaque if filename.match?(SQLITE_MEMORY_MATCHER)
+          return opaque if query.include?(SQLITE_MEMORY_QUERY)
+          return opaque unless filename.match?(SQLITE_FILENAME_MATCHER)
+
+          prefix + database_filename(filename) + separator + query
         end
 
         # Transform filename as with URI paths, but account for extname

--- a/spec/unit/testing/database_url_spec.rb
+++ b/spec/unit/testing/database_url_spec.rb
@@ -75,5 +75,210 @@ RSpec.describe Hanami::DB::Testing do
       url = "sqlite::memory"
       expect(subject.call(url)).to eq "sqlite::memory"
     end
+
+    it "transforms a single-colon relative path" do
+      url = "sqlite:db/development.sqlite3"
+      expect(subject.call(url)).to eq "sqlite:db/test.sqlite3"
+    end
+
+    it "transforms a single-colon _dev filename" do
+      expect(subject.call("sqlite:app_dev.db")).to eq "sqlite:app_test.db"
+    end
+
+    it "ignores a single-colon in-memory database" do
+      url = "sqlite:file::memory:?cache=shared"
+      expect(subject.call(url)).to eq url
+    end
+  end
+
+  context "jdbc prefix" do
+    context "postgresql scheme" do
+      it "transforms _development to _test" do
+        expect(subject.call("jdbc:postgresql://h/app_development")).to eq "jdbc:postgresql://h/app_test"
+      end
+
+      it "transforms _dev to _test" do
+        expect(subject.call("jdbc:postgresql://h/app_dev")).to eq "jdbc:postgresql://h/app_test"
+      end
+
+      it "appends to non-conforming paths" do
+        expect(subject.call("jdbc:postgresql://h/app")).to eq "jdbc:postgresql://h/app_test"
+      end
+
+      it "does not transform _test" do
+        expect(subject.call("jdbc:postgresql://h/app_test")).to eq "jdbc:postgresql://h/app_test"
+      end
+
+      it "accepts any #to_s object such as URI" do
+        url = URI("jdbc:postgresql://localhost:5432/bookshelf_development")
+        expect(subject.call(url)).to eq "jdbc:postgresql://localhost:5432/bookshelf_test"
+      end
+    end
+
+    context "mysql scheme" do
+      it "transforms _development to _test, preserving the port" do
+        expect(subject.call("jdbc:mysql://h:3306/app_development")).to eq "jdbc:mysql://h:3306/app_test"
+      end
+
+      it "transforms _dev to _test" do
+        expect(subject.call("jdbc:mysql://h:3306/app_dev")).to eq "jdbc:mysql://h:3306/app_test"
+      end
+
+      it "does not transform _test" do
+        expect(subject.call("jdbc:mysql://h:3306/app_test")).to eq "jdbc:mysql://h:3306/app_test"
+      end
+
+      it "appends to non-conforming paths" do
+        expect(subject.call("jdbc:mysql://h:3306/app")).to eq "jdbc:mysql://h:3306/app_test"
+      end
+    end
+
+    context "sqlite scheme" do
+      it "transforms a hierarchical path" do
+        expect(subject.call("jdbc:sqlite://db/app.sqlite3")).to eq "jdbc:sqlite://db/app_test.sqlite3"
+      end
+
+      it "transforms an absolute opaque path" do
+        expect(subject.call("jdbc:sqlite:/abs/bookshelf_dev.db")).to eq "jdbc:sqlite:/abs/bookshelf_test.db"
+      end
+
+      it "transforms a relative opaque path" do
+        expect(subject.call("jdbc:sqlite:db/development.sqlite3")).to eq "jdbc:sqlite:db/test.sqlite3"
+      end
+
+      it "transforms a relative opaque path with a query string" do
+        url = "jdbc:sqlite:db/development.sqlite3?journal_mode=WAL"
+        expect(subject.call(url)).to eq "jdbc:sqlite:db/test.sqlite3?journal_mode=WAL"
+      end
+
+      it "transforms an opaque _development filename" do
+        url = "jdbc:sqlite:db/app_development.sqlite3"
+        expect(subject.call(url)).to eq "jdbc:sqlite:db/app_test.sqlite3"
+      end
+
+      it "appends to a non-conforming opaque filename" do
+        expect(subject.call("jdbc:sqlite:db/app.sqlite3")).to eq "jdbc:sqlite:db/app_test.sqlite3"
+      end
+
+      it "does not transform an already-_test opaque path" do
+        url = "jdbc:sqlite:db/app_test.sqlite3"
+        expect(subject.call(url)).to eq "jdbc:sqlite:db/app_test.sqlite3"
+      end
+
+      it "transforms a Windows drive-letter opaque path" do
+        url = "jdbc:sqlite:C:/data/app_development.db"
+        expect(subject.call(url)).to eq "jdbc:sqlite:C:/data/app_test.db"
+      end
+
+      it "transforms an on-disk file: URI filename" do
+        url = "jdbc:sqlite:file:db/app_development.db"
+        expect(subject.call(url)).to eq "jdbc:sqlite:file:db/app_test.db"
+      end
+
+      it "transforms an on-disk file: URI filename with a query" do
+        url = "jdbc:sqlite:file:data/sample.db?mode=ro"
+        expect(subject.call(url)).to eq "jdbc:sqlite:file:data/sample_test.db?mode=ro"
+      end
+    end
+
+    context "single-colon postgresql scheme" do
+      it "transforms the host-less _development shorthand" do
+        url = "jdbc:postgresql:bookshelf_development"
+        expect(subject.call(url)).to eq "jdbc:postgresql:bookshelf_test"
+      end
+
+      it "appends to a non-conforming database name" do
+        expect(subject.call("jdbc:postgresql:bookshelf")).to eq "jdbc:postgresql:bookshelf_test"
+      end
+
+      it "does not transform an already-_test database name" do
+        url = "jdbc:postgresql:bookshelf_test"
+        expect(subject.call(url)).to eq "jdbc:postgresql:bookshelf_test"
+      end
+
+      it "preserves a query string" do
+        url = "jdbc:postgresql:bookshelf_dev?ssl=true"
+        expect(subject.call(url)).to eq "jdbc:postgresql:bookshelf_test?ssl=true"
+      end
+    end
+
+    describe "in-memory databases" do
+      it "ignores the file: URI-filename form" do
+        url = "jdbc:sqlite:file::memory:?cache=private"
+        expect(subject.call(url)).to eq url
+      end
+
+      it "ignores the bare :memory: form" do
+        expect(subject.call("jdbc:sqlite::memory:")).to eq "jdbc:sqlite::memory:"
+      end
+
+      it "ignores a named in-memory database" do
+        url = "jdbc:sqlite:file:app?mode=memory"
+        expect(subject.call(url)).to eq url
+      end
+
+      it "ignores a named shared-cache in-memory database" do
+        url = "jdbc:sqlite:file:memdb1?mode=memory&cache=shared"
+        expect(subject.call(url)).to eq url
+      end
+
+      it "ignores :memory: carrying a query string" do
+        url = "jdbc:sqlite::memory:?cache=shared"
+        expect(subject.call(url)).to eq url
+      end
+    end
+
+    describe "round trip" do
+      it "preserves credentials, port and query params" do
+        url = "jdbc:postgresql://user:pass@localhost:5432/bookshelf_development?ssl=true"
+        expect(subject.call(url)).to eq "jdbc:postgresql://user:pass@localhost:5432/bookshelf_test?ssl=true"
+      end
+
+      it "preserves a socket host query param" do
+        url = "jdbc:postgresql://user:pass@/bookshelf_dev?host=/var/run/postgresql/.s.PGSQL.5432"
+        expect(subject.call(url)).to eq(
+          "jdbc:postgresql://user:pass@/bookshelf_test?host=/var/run/postgresql/.s.PGSQL.5432"
+        )
+      end
+    end
+
+    describe "unrecognised subprotocols" do
+      # Only postgresql, mysql and sqlite name their databases in a way this
+      # transformation understands. Everything else must round-trip untouched
+      # rather than be mangled by the generic path branches.
+      [
+        "jdbc:h2:mem:test",
+        "jdbc:h2:./db/development",
+        "jdbc:derby:db/development",
+        "jdbc:db2://h:50000/APPDEV",
+        "jdbc:db2://host:50000/APPDEV:currentSchema=x;",
+        "jdbc:as400://host/lib;naming=system",
+        "jdbc:sqlserver://h;databaseName=bookshelf_development",
+        "jdbc:informix-sqli://h:1533/app_development:INFORMIXSERVER=x"
+      ].each do |url|
+        it "leaves #{url} untouched" do
+          expect(subject.call(url)).to eq url
+        end
+      end
+    end
+
+    describe "unparseable remainders" do
+      # Stripping the prefix turns an always-parseable opaque URI into a
+      # hierarchical one that URI can reject. Such URLs must keep no-opping,
+      # not raise out of Hanami::Providers::DB#detect_database_urls_from_env.
+      [
+        "jdbc:sqlserver://localhost:1433;databaseName=app_development",
+        "jdbc:postgresql://h1:5432,h2:5432/app_development",
+        "jdbc:mysql://host1:3306,host2:3306/app_development",
+        "jdbc:sqlite:",
+        "jdbc:sqlite://",
+        "jdbc:sqlite:?foo=bar"
+      ].each do |url|
+        it "returns #{url} unchanged without raising" do
+          expect { subject.call(url) }.not_to raise_error
+          expect(subject.call(url)).to eq url
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
Previously they were returned unchanged, so on JRuby a test-env database URL still pointed at the development database and running the suite truncated or migrated development data.

Incrementally marching towards full JRuby support, as well as prepping for first-class hanami-db operations 👀 