### PR TITLE
Add Postgres and MySQL services to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,8 +35,6 @@ jobs:
       COVERAGE: ${{ matrix.coverage }}
       # Env below included from ./repo-sync-extensions/ci-env.yml
       POSTGRES_BASE_URL: postgres://postgres:password@localhost:5432/hanami_db_test
-      # Enable ObjectSpace for tests
-      JRUBY_OPTS: "-X+O"
     # Services included from ./repo-sync-extensions/ci-services.yml
     services:
       mysql:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,6 +33,37 @@ jobs:
             coverage: "true"
     env:
       COVERAGE: ${{ matrix.coverage }}
+      # Env below included from ./repo-sync-extensions/ci-env.yml
+      POSTGRES_BASE_URL: postgres://postgres:password@localhost:5432/hanami_db_test
+      # Enable ObjectSpace for tests
+      JRUBY_OPTS: "-X+O"
+    # Services included from ./repo-sync-extensions/ci-services.yml
+    services:
+      mysql:
+        image: mysql:9.6.0
+        env:
+          MYSQL_ROOT_PASSWORD: password
+        ports:
+          - 3307:3306
+        options: >-
+          --health-cmd "mysqladmin ping"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 3
+      postgres:
+        # Use postgres:14 for CLI compatibility with ubuntu-latest, currently ubuntu-22.04
+        # See https://github.com/actions/runner-images/blob/main/images/ubuntu/Ubuntu2204-Readme.md
+        image: postgres:14
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: password
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
     steps:
       - name: Checkout
         uses: actions/checkout@0c366fd6a839edf440554fa01a7085ccba70ac98

--- a/.github/workflows/repo-sync-extensions/ci-env.yml
+++ b/.github/workflows/repo-sync-extensions/ci-env.yml
@@ -1,0 +1,3 @@
+POSTGRES_BASE_URL: postgres://postgres:password@localhost:5432/hanami_db_test
+# Enable ObjectSpace for tests
+JRUBY_OPTS: "-X+O"

--- a/.github/workflows/repo-sync-extensions/ci-env.yml
+++ b/.github/workflows/repo-sync-extensions/ci-env.yml
@@ -1,3 +1,1 @@
 POSTGRES_BASE_URL: postgres://postgres:password@localhost:5432/hanami_db_test
-# Enable ObjectSpace for tests
-JRUBY_OPTS: "-X+O"

--- a/.github/workflows/repo-sync-extensions/ci-services.yml
+++ b/.github/workflows/repo-sync-extensions/ci-services.yml
@@ -1,0 +1,25 @@
+mysql:
+  image: mysql:9.6.0
+  env:
+    MYSQL_ROOT_PASSWORD: password
+  ports:
+    - 3307:3306
+  options: >-
+    --health-cmd "mysqladmin ping"
+    --health-interval 10s
+    --health-timeout 5s
+    --health-retries 3
+postgres:
+  # Use postgres:14 for CLI compatibility with ubuntu-latest, currently ubuntu-22.04
+  # See https://github.com/actions/runner-images/blob/main/images/ubuntu/Ubuntu2204-Readme.md
+  image: postgres:14
+  env:
+    POSTGRES_USER: postgres
+    POSTGRES_PASSWORD: password
+  ports:
+    - 5432:5432
+  options: >-
+    --health-cmd pg_isready
+    --health-interval 10s
+    --health-timeout 5s
+    --health-retries 5

--- a/Gemfile
+++ b/Gemfile
@@ -8,8 +8,17 @@ gemspec
 
 gem "hanami-devtools", github: "hanami/devtools", branch: "main"
 
-gem "sqlite3", platform: :mri
-gem "jdbc-sqlite3", platform: :jruby
+platforms :mri do
+  gem "mysql2"
+  gem "pg"
+  gem "sqlite3"
+end
+
+platforms :jruby do
+  gem "jdbc-mysql"
+  gem "jdbc-postgres"
+  gem "jdbc-sqlite3"
+end
 
 group :docs do
   gem "redcarpet", platforms: :mri

--- a/README.md
+++ b/README.md
@@ -27,16 +27,18 @@ $ bundle
 ## Development
 
 Most of the test suite runs against SQLite and needs no setup. The specs that exercise Postgres and
-MySQL need those servers running, which `docker compose` provides:
+MySQL need those servers running, which `docker compose` provides. This needs
+[Docker](https://docs.docker.com/get-started/get-docker/) installed: Docker Desktop on macOS and
+Windows, or Docker Engine with the Compose plugin on Linux.
 
 ```shell
 $ docker compose up -d
 $ bundle exec rspec
 ```
 
-Postgres listens on 5433 and MySQL on 3307 locally, so they don't collide with any servers you
-already have installed. CI uses the default ports; override with `POSTGRES_BASE_URL` if your setup
-differs.
+Locally, Postgres listens on 5433 and MySQL on 3307, so they don't collide with any servers you
+already have installed. CI runs Postgres on its default 5432 and MySQL on 3307. Override
+`POSTGRES_BASE_URL` if your setup differs.
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -24,6 +24,20 @@ And then execute:
 $ bundle
 ```
 
+## Development
+
+Most of the test suite runs against SQLite and needs no setup. The specs that exercise Postgres and
+MySQL need those servers running, which `docker compose` provides:
+
+```shell
+$ docker compose up -d
+$ bundle exec rspec
+```
+
+Postgres listens on 5433 and MySQL on 3307 locally, so they don't collide with any servers you
+already have installed. CI uses the default ports; override with `POSTGRES_BASE_URL` if your setup
+differs.
+
 ## Contributing
 
 1. Fork it

--- a/README.repo.md
+++ b/README.repo.md
@@ -15,16 +15,18 @@ $ bundle
 ## Development
 
 Most of the test suite runs against SQLite and needs no setup. The specs that exercise Postgres and
-MySQL need those servers running, which `docker compose` provides:
+MySQL need those servers running, which `docker compose` provides. This needs
+[Docker](https://docs.docker.com/get-started/get-docker/) installed: Docker Desktop on macOS and
+Windows, or Docker Engine with the Compose plugin on Linux.
 
 ```shell
 $ docker compose up -d
 $ bundle exec rspec
 ```
 
-Postgres listens on 5433 and MySQL on 3307 locally, so they don't collide with any servers you
-already have installed. CI uses the default ports; override with `POSTGRES_BASE_URL` if your setup
-differs.
+Locally, Postgres listens on 5433 and MySQL on 3307, so they don't collide with any servers you
+already have installed. CI runs Postgres on its default 5432 and MySQL on 3307. Override
+`POSTGRES_BASE_URL` if your setup differs.
 
 ## Contributing
 

--- a/README.repo.md
+++ b/README.repo.md
@@ -12,6 +12,20 @@ And then execute:
 $ bundle
 ```
 
+## Development
+
+Most of the test suite runs against SQLite and needs no setup. The specs that exercise Postgres and
+MySQL need those servers running, which `docker compose` provides:
+
+```shell
+$ docker compose up -d
+$ bundle exec rspec
+```
+
+Postgres listens on 5433 and MySQL on 3307 locally, so they don't collide with any servers you
+already have installed. CI uses the default ports; override with `POSTGRES_BASE_URL` if your setup
+differs.
+
 ## Contributing
 
 1. Fork it

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,14 @@
+services:
+  mysql:
+    image: mysql:latest
+    ports:
+      - 3307:3306
+    environment:
+      MYSQL_ROOT_PASSWORD: password
+  postgres:
+    image: postgres:latest
+    ports:
+      - 5433:5432
+    environment:
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: password


### PR DESCRIPTION
Groundwork for [hanami/roadmap#9](https://github.com/hanami/roadmap/issues/9), which moves database management out of `hanami-cli` into this gem. Those APIs need real database servers to test against, and CI doesn't currently have it.

- Postgres and MySQL CI services, via `.github/workflows/repo-sync-extensions/` (same shape as `hanami-cli`)
- `pg` / `mysql2` on MRI, `jdbc-postgres` / `jdbc-mysql` on JRuby
- `docker-compose.yml` for local runs — Postgres on 5433, MySQL on 3307, so they don't
  collide with locally installed servers

`ci.yml` is regenerated, not hand-edited: `bin/local-sync --group hanami` produces this file properly, so the next sync is a no-op.